### PR TITLE
Here's the commit message:

### DIFF
--- a/app/environment.yml
+++ b/app/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.11  # Or your preferred Python version
   - pandas==2.2.0
   - requests==2.31.0
-  - jinaai==0.9.4 # Or jina, if you prefer the original Jina library
+  - jinaai==0.2.10 # Or jina, if you prefer the original Jina library
   - beautifulsoup4==4.12.3
   - html2text==2020.1.16
   - scikit-learn==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ fastapi==0.109.2
 html2text==2020.1.16
 httpx==0.26.0
 ipykernel==6.29.3
-jinaai==0.9.4
+jinaai==0.2.10
 meilisearch==0.35.0
 neo4j==5.14.1
 notebook==7.1.2


### PR DESCRIPTION
fix: Correct jinaai package version for CI build

The CI build was failing due to an incorrect version pin for the `jinaai` package. Version `0.9.4` was specified, but it is not an available version.

This commit updates the `jinaai` package version to `0.2.10`, which is listed as an available version, to resolve the build error.

Changes:
- Updated `jinaai==0.9.4` to `jinaai==0.2.10` in `requirements.txt`.
- Updated `jinaai==0.9.4` to `jinaai==0.2.10` in `app/environment.yml` for consistency.