### PR TITLE
fix: Correct meilisearch package version for CI build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ html2text==2020.1.16
 httpx==0.26.0
 ipykernel==6.29.3
 jinaai==0.2.10
-meilisearch==0.35.0
+meilisearch==0.34.1
 neo4j==5.14.1
 notebook==7.1.2
 numpy==1.26.3


### PR DESCRIPTION
The CI build failed due to an incorrect version pin for the `meilisearch` package. Version `0.35.0` was specified, but it is not an available version according to pip.

This commit updates the `meilisearch` package version to `0.34.1`, which is indicated as an available version from the CI error log, to resolve the build error.

Changes:
- Updated `meilisearch==0.35.0` to `meilisearch==0.34.1` in `requirements.txt`.