### PR TITLE
fix: Update neo4j package version to resolve CI build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ httpx==0.26.0
 ipykernel==6.29.3
 jinaai==0.2.10
 meilisearch==0.34.1
-neo4j==5.14.1
+neo4j==5.20.0
 notebook==7.1.2
 numpy==1.26.3
 pandas==2.2.0


### PR DESCRIPTION
The CI build was failing with a "metadata-generation-failed" error for `neo4j==5.14.1`, potentially due to build issues with Python 3.13.3 or missing build dependencies in the CI environment.

This commit updates the `neo4j` package version to `5.20.0`, a more recent stable version, in an attempt to resolve this build issue. This version is assumed to have better compatibility or wheel availability for newer Python versions.

Changes:
- Updated `neo4j==5.14.1` to `neo4j==5.20.0` in `requirements.txt`.