### PR TITLE
fix: Update pandas package version to resolve CI build error

### DIFF
--- a/app/environment.yml
+++ b/app/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.11  # Or your preferred Python version
-  - pandas==2.2.0
+  - pandas==2.2.2
   - requests==2.31.0
   - jinaai==0.2.10 # Or jina, if you prefer the original Jina library
   - beautifulsoup4==4.12.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ meilisearch==0.34.1
 neo4j==5.20.0
 notebook==7.1.2
 numpy==1.26.3
-pandas==2.2.0
+pandas==2.2.2
 pydantic==2.6.1
 pydantic-settings==2.2.1
 pytest==8.3.4


### PR DESCRIPTION
The CI build was failing during the installation of `pandas==2.2.0` with a "metadata-generation-failed" error, likely due to C++ compilation issues when building from source on Python 3.13.3.

This commit updates the `pandas` package version to `2.2.2`. It is hoped that this patch version has better pre-compiled wheel availability for Python 3.13 or includes fixes for build issues with newer compilers / Cython versions.

Changes:
- Updated `pandas==2.2.0` to `pandas==2.2.2` in `requirements.txt`.
- Updated `pandas==2.2.0` to `pandas==2.2.2` in `app/environment.yml` for consistency.